### PR TITLE
Move regex dynamic regex creations to static variables

### DIFF
--- a/Lib/ManiaLink.cs
+++ b/Lib/ManiaLink.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 
@@ -9,6 +10,11 @@ public class ManiaLink
 {
     private readonly Type _type;
     private readonly MethodInfo _renderMethod;
+
+    private static readonly Regex ReplaceDefaultAttr =
+        new(
+            @"\s(\w[\w0-9]*=""\s*""|(pos|size)=""0 0""|(z-index|rot|scriptevents|textemboss|autonewline|maxline|translate)=""0""|(scale|opacity)=""1""|valign=""top""|halign=""left"")",
+            RegexOptions.IgnoreCase);
 
     public ManiaLink(string tag, string preCompiledTemplate, Assembly context)
     {
@@ -44,36 +50,6 @@ public class ManiaLink
 
         var output = (string?)_renderMethod.Invoke(runnable, null);
 
-        return output?.Replace(@"pos=""0 0""", "")
-            .Replace(@"size=""0 0""", "")
-            .Replace(@"z-index=""0""", "")
-            .Replace(@"scale=""1""", "")
-            .Replace(@"rot=""0""", "")
-            .Replace(@"scriptevents=""0""", "")
-            .Replace(@"opacity=""1""", "")
-            .Replace(@"valign=""top""", "")
-            .Replace(@"halign=""left""", "")
-            .Replace(@"textemboss=""0""", "")
-            .Replace(@"autonewline=""0""", "")
-            .Replace(@"textprefix=""""", "")
-            .Replace(@"textcolor=""""", "")
-            .Replace(@"focusareacolor1=""""", "")
-            .Replace(@"focusareacolor2=""""", "")
-            .Replace(@"maxline=""0""", "")
-            .Replace(@"translate=""0""", "")
-            .Replace(@"ScriptEvents=""0""", "")
-            .Replace(@"textid=""""", "")
-            .Replace(@"textfont=""""", "")
-            .Replace(@"image=""""", "")
-            .Replace(@"imagefocus=""""", "")
-            .Replace(@"substyle=""""", "")
-            .Replace(@"styleselected=""""", "")
-            .Replace(@"colorize=""""", "")
-            .Replace(@"modulatecolor=""""", "")
-            .Replace(@"action=""""", "")
-            .Replace(@"url=""""", "")
-            .Replace(@"class=""""", "")
-            .Replace(@"manialink=""""", "")
-            .Replace(@"style=""""", "");
+        return output == null ? null : ReplaceDefaultAttr.Replace(output, "");
     }
 }

--- a/ManiaTemplateEngine.cs
+++ b/ManiaTemplateEngine.cs
@@ -39,7 +39,7 @@ public class ManiaTemplateEngine
                 out string[] loadedAssemblies);
 
         //Remove namespace wrapper
-        preCompiledTemplate = preCompiledTemplate.Replace("namespace ManiaTemplate {", "")[..^5];
+        preCompiledTemplate = preCompiledTemplate.Replace("namespace ManiaTemplate {", "")[..^2];
 
         return new ManiaLink(mtComponent.Tag, preCompiledTemplate, Assembly.GetCallingAssembly());
     }


### PR DESCRIPTION
This commit includes a change that affects #8 as a single regex replaces all empty properties and default values, that were already replaced in previous commits. 

Fixes #7.

It also includes a fix to solve the problem of maniatemplates not compiling, because of a falsely formatted generated file. 